### PR TITLE
Implement Basic Authentication for Dashboard Access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ docker-compose.override.yml
 
 # Traefik
 certificates/
+users.htpasswd
 
 # Operating System
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A robust QR code generation and management API built with FastAPI and SQLite. Fe
 -   **Edge Security Model**:
     -   **Network-level Access Control**: IP allowlisting for administrative functionality via Traefik
     -   **Path-based Protection**: Only `/r/{short_id}` endpoints exposed on public domains
-    -   **No Authentication Required**: Simplified security model without user management
+    -   **Basic Authentication**: Dashboard access protected by username/password
 -   **Web Interface**: Manage QR codes through an intuitive web UI built with Jinja2 templates and Bootstrap.
 -   **RESTful API**: Comprehensive API for programmatic QR code management.
 -   **Docker & Traefik**: Production-ready deployment with HTTPS support, reverse proxying, and load balancing capabilities provided by Traefik.
@@ -32,6 +32,7 @@ To run the QR Code Generator locally using Docker Compose:
 **Access Points:**
 
 -   **Web Interface**: `https://localhost/` (e.g., `/`, `/qr-list`, `/qr-create`)
+    -   Requires basic authentication for dashboard access
 -   **API Docs**: `https://localhost/docs`
 -   **API Base URL**: `https://localhost/api/v1`
 -   **Traefik Dashboard**: `http://localhost:8080/`
@@ -55,15 +56,20 @@ The application uses a simplified security model based on network-level controls
    - Path-based routing restrictions (only `/r/{short_id}` accessible on public domains)
    - TLS termination at the edge
 
-2. **Environment Variables**:
+2. **Basic Authentication**:
+   - Dashboard access protected with username/password authentication
+   - Credentials managed via Traefik's basicAuth middleware
+   - Layered security approach (IP whitelisting + basic authentication)
+
+3. **Environment Variables**:
    ```dotenv
    # Basic configuration
    BASE_URL=https://10.1.6.12
    ```
 
-3. **No Authentication Required**:
-   - Administrative endpoints are protected via network-level controls
-   - No user management or login required
+4. **No Complex Authentication System**:
+   - Administrative endpoints are protected via network-level controls and basic authentication
+   - No complex user management or JWT/OAuth required
    - Simplified deployment and maintenance
 
 ## Infrastructure Architecture
@@ -213,6 +219,7 @@ Key variables include:
     -   Path-based routing to restrict public access to only `/r/{short_id}` paths
     -   Security headers (HSTS, Content-Security-Policy, etc.)
     -   Rate limiting for public endpoints
+    -   Basic authentication for dashboard access
 
 -   **Application Security:**
     -   Input validation through Pydantic models
@@ -269,6 +276,7 @@ The `init.sh` script automatically handles validation and migration checks on co
 -   **Traefik Issues**: Check Traefik logs (`docker-compose logs traefik`) or the Traefik dashboard for routing or middleware errors.
 -   **QR Redirect Issues**: Check for valid short_id and updated redirect URL in the database.
 -   **SQLite Permissions**: Ensure the `/app/data` directory in the container has the correct permissions.
+-   **Authentication Issues**: Verify that `users.htpasswd` is correctly mounted in the Traefik container and has appropriate permissions (600). Check that the middleware is correctly configured in `dynamic_conf.yml`.
 
 ## License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,7 @@ services:
       - ./certs:/etc/certs:ro
       - ./traefik.yml:/etc/traefik/traefik.yml:ro
       - ./dynamic_conf.yml:/etc/traefik/dynamic_conf.yml:ro
+      - ./users.htpasswd:/etc/traefik/users.htpasswd:ro
       - traefik_logs:/logs/traefik
     ports:
       - "80:80"

--- a/dynamic_conf.yml
+++ b/dynamic_conf.yml
@@ -102,6 +102,7 @@ http:
       middlewares:
         - redirect-to-https@file
         - ip-whitelist@file
+        - dashboard-auth@file
         - security-headers@file
       priority: 600
 
@@ -113,6 +114,7 @@ http:
       tls: {}  # Use default certificate store
       middlewares:
         - ip-whitelist@file
+        - dashboard-auth@file
         - security-headers@file
       priority: 600
       
@@ -233,6 +235,12 @@ http:
         forceSTSHeader: true
         contentSecurityPolicy: "frame-ancestors 'self'; frame-src 'self'; object-src 'none';"
         customFrameOptionsValue: "DENY"
+
+    # Dashboard Basic Authentication
+    dashboard-auth:
+      basicAuth:
+        usersFile: "/etc/traefik/users.htpasswd"
+        realm: "QR Dashboard - Authorized Access Only"
 
   services:
     api-service:


### PR DESCRIPTION
## Summary
This PR implements basic authentication for the dashboard interface, enhancing security with a simple username/password mechanism while maintaining the existing IP-based allowlisting as the primary security layer.

## Changes
- Added a `dashboard-auth` middleware in Traefik configuration using basic authentication
- Applied the authentication middleware to internal routes (10.1.6.12)
- Configured Traefik to mount a credentials file (users.htpasswd) with a single admin account
- Updated README.md with documentation on the new authentication feature
- Added users.htpasswd to .gitignore to prevent credential files from being committed

## Security Considerations
- Basic authentication is only applied to routes already protected by IP allowlisting
- Credentials file permissions are set to 600 (owner read/write only)
- Implementation follows the edge gateway pattern with Traefik as the single source of truth for security decisions
- Simplified approach using one user account (admin_user) for dashboard access

## Testing
- Verified that accessing the dashboard now requires authentication credentials
- Confirmed the layered security approach works (IP check followed by credential check)
- Validated that QR redirect functionality remains unaffected