### PR TITLE
Reorganize Traefik routing for improved security and Keycloak preparation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,11 @@ services:
       # Application Configuration
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
       - DEBUG=${DEBUG:-false}
-      - BASE_URL=${BASE_URL:-https://10.1.6.12}
+      - BASE_URL=${BASE_URL:-https://10.1.6.12} # This should be your primary internal access URL
       # Database Configuration
       - PG_DATABASE_URL=${PG_DATABASE_URL:-postgresql+psycopg2://pguser:pgpassword@postgres:5432/qrdb}
       - ENVIRONMENT=production # Production environment settings
-      # PostgreSQL Configuration
+      # PostgreSQL Configuration (for app to connect to DB)
       - POSTGRES_USER=${POSTGRES_USER:-pguser}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-pgpassword}
       - POSTGRES_DB=${POSTGRES_DB:-qrdb}
@@ -27,13 +27,13 @@ services:
       - TEST_POSTGRES_HOST=${TEST_POSTGRES_HOST:-postgres_test}
       - TEST_POSTGRES_PORT=${TEST_POSTGRES_PORT:-5432}
       - TEST_DATABASE_URL=${TEST_DATABASE_URL:-postgresql+psycopg2://pguser_test:pgpassword_test@postgres_test:5432/qrdb_test}
-      # Cookie settings (for CSRF protection only)
-      - COOKIE_DOMAIN=${COOKIE_DOMAIN:-10.1.6.12}
+      # Cookie settings (if needed for any non-auth CSRF or future features)
+      - COOKIE_DOMAIN=${COOKIE_DOMAIN:-10.1.6.12} # Align with your internal dashboard access
     volumes:
       - qr_data:/app/data
       - ./backups:/app/backups
       - qr_logs:/logs
-      - ./app/tests:/app/app/tests
+      - ./app/tests:/app/app/tests # For development/testing if running tests inside container
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s
@@ -47,39 +47,19 @@ services:
         condition: service_healthy
     labels:
       - "traefik.enable=true"
-      # Default route (INTERNAL ONLY)
-      - "traefik.http.routers.api.rule=Host(`10.1.6.12`) && PathPrefix(`/`)"
-      - "traefik.http.services.api.loadbalancer.server.port=8000"
-      - "traefik.http.routers.api.entrypoints=web,websecure"
-      - "traefik.http.routers.api.tls=true"
-      - "traefik.http.routers.api.priority=10"
-      
-      # Public QR redirect route (PUBLIC on 130.156.44.52)
-      - "traefik.http.routers.api-public-qr.rule=Host(`130.156.44.52`) && PathPrefix(`/r/`)"
-      - "traefik.http.routers.api-public-qr.entrypoints=web,websecure"
-      - "traefik.http.routers.api-public-qr.tls=true"
-      - "traefik.http.routers.api-public-qr.service=api"
-      - "traefik.http.routers.api-public-qr.priority=500"
-      
-      # Domain-specific route for future use with web.hccc.edu
-      - "traefik.http.routers.api-domain.rule=Host(`web.hccc.edu`) && PathPrefix(`/`)"
-      - "traefik.http.routers.api-domain.entrypoints=web,websecure"
-      - "traefik.http.routers.api-domain.tls=true"
-      - "traefik.http.routers.api-domain.service=api"
-      - "traefik.http.routers.api-domain.priority=100"
-      
-      # Force HTTPS redirect
-      - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
-      - "traefik.http.middlewares.redirect-to-https.redirectscheme.permanent=true"
-      - "traefik.http.middlewares.cors.headers.accesscontrolallowmethods=GET,POST,PUT,DELETE,OPTIONS"
-      - "traefik.http.middlewares.cors.headers.accesscontrolalloworiginlist=https://10.1.6.12"
-      - "traefik.http.middlewares.cors.headers.accesscontrolmaxage=100"
-      - "traefik.http.middlewares.cors.headers.addvaryheader=true"
-      - "traefik.http.routers.api.middlewares=redirect-to-https@docker,cors@docker"
-      - "traefik.http.routers.api-domain.middlewares=redirect-to-https@docker,cors@docker"
-      - "traefik.http.routers.api-public-qr.middlewares=redirect-to-https@docker"
+      # Define the service for Traefik.
+      # The actual routing rules, entrypoints, and middlewares are now primarily in dynamic_conf.yml,
+      # which will refer to this service as 'api-service'.
+      - "traefik.http.services.api-service.loadbalancer.server.port=8000"
+      # Optional: If you want a very low priority, Docker-provider-specific default router
+      # for this service *if no rules in dynamic_conf.yml match it*.
+      # This is generally not needed if dynamic_conf.yml is comprehensive.
+      # - "traefik.http.routers.api-docker-catchall.rule=Host(`your-internal-docker-host.example.com`)" # Replace with a real, unique internal hostname
+      # - "traefik.http.routers.api-docker-catchall.service=api-service"
+      # - "traefik.http.routers.api-docker-catchall.priority=1" # Lowest priority
+      # - "traefik.http.routers.api-docker-catchall.entrypoints=web"
 
-  # PostgreSQL service
+  # PostgreSQL service (Production DB)
   postgres:
     image: postgres:15
     container_name: qr_generator_postgres
@@ -96,8 +76,7 @@ services:
       timeout: 5s
       retries: 5
     restart: unless-stopped
-    # Expose port only internally, not to host
-    expose:
+    expose: # Expose only to other containers on the same Docker network
       - "5432"
 
   # PostgreSQL Test service
@@ -107,7 +86,7 @@ services:
     environment:
       - POSTGRES_USER=${TEST_POSTGRES_USER:-pguser_test}
       - POSTGRES_PASSWORD=${TEST_POSTGRES_PASSWORD:-pgpassword_test}
-      - POSTGRES_DB=${TEST_POSTGRES_DB:-qrdb_test}
+      - TEST_POSTGRES_DB=${TEST_POSTGRES_DB:-qrdb_test} # Note: This should be TEST_POSTGRES_DB
       - TZ=America/New_York
     volumes:
       - postgres_test_data:/var/lib/postgresql/data
@@ -117,27 +96,28 @@ services:
       timeout: 5s
       retries: 5
     restart: unless-stopped
-    # Expose port only internally, not to host
-    expose:
+    expose: # Expose only to other containers on the same Docker network
       - "5432"
 
   traefik:
-    image: traefik:v2.10
+    image: traefik:v2.10 # Or your preferred Traefik version
     container_name: qr_generator_traefik
     # Use existing configuration files instead of command-line flags
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ./certs:/etc/certs:ro
-      - ./traefik.yml:/etc/traefik/traefik.yml:ro
-      - ./dynamic_conf.yml:/etc/traefik/dynamic_conf.yml:ro
-      - ./users.htpasswd:/etc/traefik/users.htpasswd:ro
-      - traefik_logs:/logs/traefik
+      - /var/run/docker.sock:/var/run/docker.sock:ro # So Traefik can listen to Docker events
+      - ./certs:/etc/certs:ro                         # Mount your certificates
+      - ./traefik.yml:/etc/traefik/traefik.yml:ro     # Static configuration
+      - ./dynamic_conf.yml:/etc/traefik/dynamic_conf.yml:ro # Dynamic configuration
+      - ./users.htpasswd:/etc/traefik/users.htpasswd:ro # Basic Auth users file
+      - traefik_logs:/logs/traefik # For Traefik's own logs, if configured in traefik.yml
     ports:
-      - "80:80"
-      - "443:443"
-      - "8080:8080"  # Traefik Dashboard
-      - "8082:8082"  # Metrics endpoint
+      - "80:80"       # HTTP
+      - "443:443"     # HTTPS
+      - "8080:8080"   # Traefik Dashboard (if entryPoint 'traefik' is on :8080)
+      - "8082:8082"   # Metrics endpoint (if entryPoint 'metrics' is on :8082)
     restart: unless-stopped
+    # depends_on: # Optional: if you want api to be up for traefik to configure it, though dynamic config handles this
+    #   - api
 
 networks:
   default:
@@ -154,4 +134,4 @@ volumes:
   postgres_data:
     driver: local
   postgres_test_data:
-    driver: local 
+    driver: local

--- a/dynamic_conf.yml
+++ b/dynamic_conf.yml
@@ -1,166 +1,177 @@
 # Dynamic configuration (dynamic_conf.yml)
 http:
   routers:
-    # QR Redirect router (high priority, public access)
-    qr-redirect-router:
-      rule: "(Host(`130.156.44.52`) || Host(`web.hccc.edu`)) && PathPrefix(`/r/`)"
+    # --- Goal 1: Dashboard on 10.1.6.12 (Internal IP) ---
+    internal-dashboard-router:
+      rule: "Host(`10.1.6.12`)" # Covers all paths on this host
       service: api-service
       entryPoints:
-        - web
+        - web # HTTP
       middlewares:
         - redirect-to-https@file
-        - rate-limit@file
-        - public-endpoints@file
-      priority: 500
-
-    qr-redirect-secure-router:
-      rule: "(Host(`130.156.44.52`) || Host(`web.hccc.edu`)) && PathPrefix(`/r/`)"
-      service: api-service
-      entryPoints:
-        - websecure
-      tls: {}  # Use default certificate store
-      middlewares:
-        - rate-limit@file
-        - public-endpoints@file
-      priority: 500
-
-    # Internal QR redirect router (optimized for internal network)
-    internal-qr-redirect-router:
-      rule: "Host(`10.1.6.12`) && PathPrefix(`/r/`)"
-      service: api-service
-      entryPoints:
-        - web
-      middlewares:
-        - redirect-to-https@file
-        - public-endpoints@file  # Use public-endpoints instead of ip-whitelist for faster processing
-      priority: 650  # Higher than internal-router but lower than specialized routers
-
-    internal-qr-redirect-secure-router:
-      rule: "Host(`10.1.6.12`) && PathPrefix(`/r/`)"
-      service: api-service
-      entryPoints:
-        - websecure
-      tls: {}  # Use default certificate store
-      middlewares:
-        - public-endpoints@file  # Use public-endpoints instead of ip-whitelist for faster processing
-      priority: 650  # Higher than internal-router but lower than specialized routers
-
-    # Public access-restricted page (static file path)
-    public-access-restricted-router:
-      rule: "(Host(`130.156.44.52`) || Host(`web.hccc.edu`) || Host(`130.156.44.53`) || Host(`web.auth.hccc.edu`)) && PathPrefix(`/static/access-restricted.html`)"
-      service: api-service
-      entryPoints:
-        - web
-        - websecure
-      middlewares:
-        - public-endpoints@file
+        - ip-whitelist@file      # Internal IPs only
+        - dashboard-auth@file    # Basic Auth
         - security-headers@file
-      tls: {}  # Use default certificate store
+      priority: 700 # High priority for specific internal IP
+
+    internal-dashboard-secure-router:
+      rule: "Host(`10.1.6.12`)" # Covers all paths on this host
+      service: api-service
+      entryPoints:
+        - websecure # HTTPS
+      tls: {}
+      middlewares:
+        - ip-whitelist@file      # Internal IPs only
+        - dashboard-auth@file    # Basic Auth
+        - security-headers@file
       priority: 700
 
-    # Block all other paths on public IP
-    public-ip-block-router:
-      rule: "Host(`130.156.44.52`) && !PathPrefix(`/r/`) && !PathPrefix(`/static/access-restricted.html`) && !PathPrefix(`/static/assets/`)"
+    # --- Goal 2: web.hccc.edu (Public Redirect Domain) ---
+    web-hccc-qr-redirect-router: # Handles /r/ path
+      rule: "Host(`web.hccc.edu`, `130.156.44.52`) && PathPrefix(`/r/`)"
       service: api-service
       entryPoints:
         - web
-        - websecure
       middlewares:
-        - access-restricted-redirect@file
-      priority: 600
-      
-    # Block all other paths on web.hccc.edu domain
-    domain-block-router:
-      rule: "Host(`web.hccc.edu`) && !PathPrefix(`/r/`) && !PathPrefix(`/static/access-restricted.html`) && !PathPrefix(`/static/assets/`)"
-      service: api-service
-      entryPoints:
-        - web
-        - websecure
-      middlewares:
-        - access-restricted-redirect@file
-      priority: 600
-
-    # Block all paths on new IP and domain (auth domain)
-    auth-ip-block-router:
-      rule: "(Host(`130.156.44.53`) || Host(`web.auth.hccc.edu`)) && !PathPrefix(`/static/access-restricted.html`) && !PathPrefix(`/static/assets/`)"
-      service: api-service
-      entryPoints:
-        - web
-        - websecure
-      middlewares:
-        - access-restricted-redirect@file
-      priority: 600
-
-    # Allow static assets for the access-restricted page
-    public-static-assets-router:
-      rule: "(Host(`130.156.44.52`) || Host(`web.hccc.edu`) || Host(`130.156.44.53`) || Host(`web.auth.hccc.edu`)) && PathPrefix(`/static/assets/`)"
-      service: api-service
-      entryPoints:
-        - web
-        - websecure
-      middlewares:
-        - public-endpoints@file
+        - redirect-to-https@file
+        - rate-limit@file        # Public endpoint, rate limit
+        - public-endpoints@file  # Allow all IPs for this path
         - security-headers@file
-      tls: {}  # Use default certificate store
       priority: 650
-      
-    # Internal access for all routes (10.1.6.12)
-    internal-router:
-      rule: "Host(`10.1.6.12`)"
-      service: api-service
-      entryPoints:
-        - web
-      middlewares:
-        - redirect-to-https@file
-        - ip-whitelist@file
-        - dashboard-auth@file
-        - security-headers@file
-      priority: 600
 
-    internal-secure-router:
-      rule: "Host(`10.1.6.12`)"
+    web-hccc-qr-redirect-secure-router:
+      rule: "Host(`web.hccc.edu`, `130.156.44.52`) && PathPrefix(`/r/`)"
       service: api-service
       entryPoints:
         - websecure
-      tls: {}  # Use default certificate store
+      tls: {}
       middlewares:
-        - ip-whitelist@file
-        - dashboard-auth@file
+        - rate-limit@file
+        - public-endpoints@file
         - security-headers@file
-      priority: 600
-      
-    # API routers (lower priority, restricted access)
-    api-router:
-      rule: "PathPrefix(`/`) && !PathPrefix(`/r/`) && !PathPrefix(`/health`)"
-      service: api-service
-      entryPoints:
-        - web
-      middlewares:
-        - redirect-to-https@file
-        - ip-whitelist@file
-        - security-headers@file
-      priority: 10
+      priority: 650
 
-    api-secure-router:
-      rule: "PathPrefix(`/`) && !PathPrefix(`/r/`) && !PathPrefix(`/health`)"
-      service: api-service
-      entryPoints:
-        - websecure
-      tls: {}  # Use default certificate store
-      middlewares:
-        - ip-whitelist@file
-        - security-headers@file
-      priority: 10
-      
-    # Health check endpoint (public access)
-    health-router:
-      rule: "PathPrefix(`/health`)"
+    web-hccc-static-assets-router: # Handles static assets for restricted page
+      rule: "Host(`web.hccc.edu`, `130.156.44.52`) && PathPrefix(`/static/assets/`)"
       service: api-service
       entryPoints:
         - web
       middlewares:
         - redirect-to-https@file
         - public-endpoints@file
+        - security-headers@file
+      priority: 640 # Needs to be higher than the catch-all redirect
+
+    web-hccc-static-assets-secure-router:
+      rule: "Host(`web.hccc.edu`, `130.156.44.52`) && PathPrefix(`/static/assets/`)"
+      service: api-service
+      entryPoints:
+        - websecure
+      tls: {}
+      middlewares:
+        - public-endpoints@file
+        - security-headers@file
+      priority: 640
+
+    web-hccc-access-restricted-page-router: # Serves the actual restricted page
+      rule: "Host(`web.hccc.edu`, `130.156.44.52`) && Path(`/static/access-restricted.html`)" # Exact path
+      service: api-service
+      entryPoints:
+        - web
+      middlewares:
+        - redirect-to-https@file
+        - public-endpoints@file
+        - security-headers@file
+      priority: 630 # Higher than the catch-all redirect
+
+    web-hccc-access-restricted-page-secure-router:
+      rule: "Host(`web.hccc.edu`, `130.156.44.52`) && Path(`/static/access-restricted.html`)"
+      service: api-service
+      entryPoints:
+        - websecure
+      tls: {}
+      middlewares:
+        - public-endpoints@file
+        - security-headers@file
+      priority: 630
+
+    web-hccc-catch-all-redirect-router: # Catches everything else on web.hccc.edu
+      rule: "Host(`web.hccc.edu`, `130.156.44.52`)" # Lowest priority for this host
+      service: api-service # Dummy service, middleware handles it
+      entryPoints:
+        - web
+        - websecure # Important: handle for HTTPS too
+      tls: {} # For websecure
+      middlewares:
+        - access-restricted-redirect@file # Redirects to the static page
+      priority: 100 # Low priority for this host, catches unmatched paths
+
+    # --- Goal 3: auth.hccc.edu (Placeholder for Keycloak) ---
+    auth-hccc-static-assets-router: # Handles static assets for restricted page
+      rule: "Host(`auth.hccc.edu`, `130.156.44.53`) && PathPrefix(`/static/assets/`)"
+      service: api-service
+      entryPoints:
+        - web
+      middlewares:
+        - redirect-to-https@file
+        - public-endpoints@file
+        - security-headers@file
+      priority: 540
+
+    auth-hccc-static-assets-secure-router:
+      rule: "Host(`auth.hccc.edu`, `130.156.44.53`) && PathPrefix(`/static/assets/`)"
+      service: api-service
+      entryPoints:
+        - websecure
+      tls: {}
+      middlewares:
+        - public-endpoints@file
+        - security-headers@file
+      priority: 540
+
+    auth-hccc-access-restricted-page-router: # Serves the actual restricted page
+      rule: "Host(`auth.hccc.edu`, `130.156.44.53`) && Path(`/static/access-restricted.html`)"
+      service: api-service
+      entryPoints:
+        - web
+      middlewares:
+        - redirect-to-https@file
+        - public-endpoints@file
+        - security-headers@file
+      priority: 530
+
+    auth-hccc-access-restricted-page-secure-router:
+      rule: "Host(`auth.hccc.edu`, `130.156.44.53`) && Path(`/static/access-restricted.html`)"
+      service: api-service
+      entryPoints:
+        - websecure
+      tls: {}
+      middlewares:
+        - public-endpoints@file
+        - security-headers@file
+      priority: 530
+
+    auth-hccc-catch-all-redirect-router: # Catches ALL paths on auth.hccc.edu
+      rule: "Host(`auth.hccc.edu`, `130.156.44.53`)"
+      service: api-service # Dummy service
+      entryPoints:
+        - web
+        - websecure # Important
+      tls: {} # For websecure
+      middlewares:
+        - access-restricted-redirect@file
+      priority: 90 # Lowest priority for this host
+
+    # --- Health Check (Public) ---
+    health-router:
+      rule: "PathPrefix(`/health`)" # Could be Host-specific if needed, but generally public
+      service: api-service
+      entryPoints:
+        - web
+      middlewares:
+        - redirect-to-https@file
+        - public-endpoints@file # Allow all IPs
+        - security-headers@file
       priority: 400
 
     health-secure-router:
@@ -168,73 +179,57 @@ http:
       service: api-service
       entryPoints:
         - websecure
-      tls: {}  # Use default certificate store
+      tls: {}
       middlewares:
         - public-endpoints@file
+        - security-headers@file
       priority: 400
 
-    # Domain-based routers (highest priority) - will be ready when DNS is set up
-    api-domain-router:
-      rule: "Host(`admin.hccc.edu`) && PathPrefix(`/`)"
-      service: api-service
+    # --- Traefik Dashboard (Internal Only) ---
+    dashboard-router: # Renamed for clarity
+      rule: "Host(`traefik.10.1.6.12`)" # Or your preferred dashboard host
+      service: api@internal # Special Traefik service
       entryPoints:
-        - web
-        - websecure
-      middlewares:
-        - redirect-to-https@file
-        - ip-whitelist@file
-        - security-headers@file
-      tls: {}  # Use default certificate store
-      priority: 200
-
-    # Traefik dashboard (internal only)
-    dashboard:
-      rule: "Host(`traefik.10.1.6.12`)"
-      service: api@internal
-      entryPoints:
-        - traefik
+        - traefik # Make sure this entrypoint is defined in traefik.yml
       middlewares:
         - ip-whitelist@file
+        - dashboard-auth@file # Added Basic Auth
+      priority: 800 # Very high priority
 
   middlewares:
-    # HTTPS redirect
     redirect-to-https:
       redirectScheme:
         scheme: https
         permanent: true
-    
-    # Access restricted page redirect (replaces block-access)
+
     access-restricted-redirect:
       redirectRegex:
-        regex: "^.*$"
+        regex: "^.*$" # Matches any path
         replacement: "/static/access-restricted.html"
-        permanent: false
-    
-    # Rate limiting
+        permanent: false # Important: false, so direct access to the page itself works
+
     rate-limit:
       rateLimit:
         average: 100
         burst: 50
         period: 1m
-        
-    # IP Whitelist (for admin/internal routes)
-    ip-whitelist:
+
+    ip-whitelist: # For internal dashboard and management
       ipWhiteList:
         sourceRange:
-          - "10.1.6.0/23"     # Internal network
-          - "127.0.0.1/32"    # Localhost
-          - "172.16.0.0/12"   # Docker network
-          - "192.168.0.0/16"  # Private network
-          - "10.0.0.0/8"      # Private network
-          - "69.114.94.0/24"  # External network
-        
-    # Public endpoints middleware (no IP restrictions)
-    public-endpoints:
+          - "10.1.6.0/23"
+          - "127.0.0.1/32"
+          - "172.16.0.0/12" # Docker default bridge
+          - "192.168.0.0/16" # Common private
+          - "10.0.0.0/8" # Common private
+          - "69.114.94.0/24" # Your specified external network for admin
+          # Add other trusted IPs/ranges for admin access
+
+    public-endpoints: # For truly public paths like /r/ and /health
       ipWhiteList:
         sourceRange:
-          - "0.0.0.0/0"       # Allow all IPs
-          
-    # Security headers
+          - "0.0.0.0/0" # Allow all
+
     security-headers:
       headers:
         customResponseHeaders:
@@ -244,26 +239,25 @@ http:
         stsSeconds: 31536000
         stsIncludeSubdomains: true
         forceSTSHeader: true
-        contentSecurityPolicy: "frame-ancestors 'self'; frame-src 'self'; object-src 'none';"
+        contentSecurityPolicy: "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com; frame-ancestors 'self'; object-src 'none';" # Adjusted CSP
         customFrameOptionsValue: "DENY"
 
-    # Dashboard Basic Authentication
-    dashboard-auth:
+    dashboard-auth: # Basic Auth for dashboard/internal routes
       basicAuth:
         usersFile: "/etc/traefik/users.htpasswd"
-        realm: "QR Dashboard - Authorized Access Only"
+        realm: "QR System - Authorized Access Only"
+        # headerField: "X-WebAuth-User" # Optional: if you want to pass user to backend
 
   services:
     api-service:
       loadBalancer:
         servers:
-          - url: "http://api:8000"
+          - url: "http://api:8000" # Points to your FastAPI app container
         passHostHeader: true
-          
-# TLS configuration moved to root level
+
 tls:
   stores:
     default:
       defaultCertificate:
         certFile: /etc/certs/wildcard.crt.pem
-        keyFile: /etc/certs/wildcard.key.pem.nopass 
+        keyFile: /etc/certs/wildcard.key.pem.nopass

--- a/traefik.yml
+++ b/traefik.yml
@@ -9,7 +9,7 @@ log:
 
 # Access Logs Configuration
 accessLog:
-  filePath: "/var/log/traefik/access.log"
+  filePath: "/logs/traefik/access.log"
   format: json
   bufferingSize: 100
   filters:


### PR DESCRIPTION
### Description
This PR reorganizes the Traefik routing configuration to better support our domain-based architecture and prepare for Keycloak integration.

#### What's Changed
- **Reorganized Traefik Routing Configuration**
  - Implemented goal-oriented router organization (internal dashboard, web domain, auth domain)
  - Created properly prioritized routes for each domain and path pattern
  - Ensured consistent middleware application across all routes
  - Fixed path-based access control for sensitive endpoints

- **Streamlined Docker Compose Configuration**
  - Removed redundant router definitions from Docker labels
  - Aligned service definitions with file-based routing approach
  - Added clear documentation and organization
  - Improved environment variable handling

- **Enhanced Security Implementation**
  - Applied proper HTTPS redirects across all HTTP routes
  - Implemented consistent security headers
  - Created clear separation between public and restricted endpoints
  - Ensured proper IP allowlisting for administrative functions

#### Technical Details
- Restructured dynamic_conf.yml with higher numerical priorities for more specific routes (700+ for internal, 500-650 for domain-specific, 90-100 for catch-all)
- Created separate routers for HTTP and HTTPS variants of each route
- Implemented consistent middleware chains based on route purpose (public, internal, admin)
- Added special handling for static assets needed by access-restricted pages

#### Testing Performed
- Verified internal dashboard access at 10.1.6.12
- Confirmed QR redirects work correctly on web.hccc.edu
- Validated proper HTTPS redirects for all domains
- Tested access restriction on auth.hccc.edu domain
- Ensured static assets load properly on the access-restricted page

#### Breaking Changes
None. This is a transparent infrastructure change that maintains all existing functionality while improving organization and security.
