### PR TITLE
Implement Keycloak OIDC Authentication with Protected Hello Page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ RUN adduser --disabled-password --gecos '' appuser \
                 /logs/database \
                 /logs/traefik \
                 /app/app/static/assets/images \
+                /app/app/static/assets/images/qr_codes \
                 /app/app/static/qr_codes \
                 /app/app/templates \
                 /app/test_advanced_qr_images \
@@ -69,6 +70,8 @@ RUN adduser --disabled-password --gecos '' appuser \
     && chmod -R 775 /logs \
     && chmod -R 777 /app/data \
     && chmod 777 /app/test_advanced_qr_images \
+    && chmod -R 777 /app/app/static/assets/images/qr_codes \
+    && chmod -R 777 /app/app/static/qr_codes \
     && chmod -R 755 /app/tests  # Ensure tests directory is readable and executable
 
 # Copy virtual environment from builder

--- a/app/templates/pages/hello_secure.html
+++ b/app/templates/pages/hello_secure.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+
+{% block title %}Secure Hello - QR Code Generator{% endblock %}
+
+{% block description %}Protected page displaying authenticated user information{% endblock %}
+
+{% block content %}
+<main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
+    <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+        <h1 class="h2">
+            <i class="bi bi-shield-lock me-2"></i>
+            Secure Page
+        </h1>
+    </div>
+
+    <div class="row">
+        <div class="col-12">
+            <div class="card shadow-sm">
+                <div class="card-body">
+                    <h5 class="card-title">Authentication Success</h5>
+                    <p class="card-text">
+                        <strong>Hello, {{ preferred_username|default('User') }} ({{ email|default('No email provided') }})!</strong>
+                    </p>
+                    <p class="card-text">
+                        You have successfully accessed a protected page through OIDC authentication.
+                    </p>
+                    <div class="mt-4">
+                        <a href="/oauth2/sign_out?rd=https://10.1.6.12/" class="btn btn-outline-danger">
+                            <i class="bi bi-box-arrow-right me-2"></i>
+                            Logout
+                        </a>
+                        <a href="/" class="btn btn-outline-primary ms-2">
+                            <i class="bi bi-house me-2"></i>
+                            Back to Dashboard
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+{% endblock %} 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       - ./tests:/app/tests # Mount the top-level tests directory for E2E tests
       - ./app/scripts:/app/scripts # Mount scripts for immediate availability without rebuild (includes init.sh)
       - test_advanced_qr_images:/app/test_advanced_qr_images # Use a named volume to avoid permission issues
+      - qr_codes_data:/app/app/static/assets/images/qr_codes # Use a named volume for QR codes
       - /var/run/docker.sock:/var/run/docker.sock:ro # Allow container to control Docker (for backup/restore API management)
       - ./.env:/app/.env:ro # Mount .env file for init.sh script
     healthcheck:
@@ -251,4 +252,6 @@ volumes:
   loki_data:
     driver: local
   test_advanced_qr_images:
+    driver: local
+  qr_codes_data:
     driver: local

--- a/dynamic_conf.yml
+++ b/dynamic_conf.yml
@@ -106,8 +106,32 @@ http:
         - access-restricted-redirect@file # Redirects to the static page
       priority: 100 # Low priority for this host, catches unmatched paths
 
-    # --- Goal 3: auth.hccc.edu (Placeholder for Keycloak) ---
-    auth-hccc-static-assets-router: # Handles static assets for restricted page
+    # --- Goal 3: auth.hccc.edu (Keycloak Authentication) ---
+    # Main Keycloak router for auth.hccc.edu
+    auth-hccc-keycloak-router:
+      rule: "Host(`auth.hccc.edu`, `130.156.44.53`)"
+      service: keycloak-service
+      entryPoints:
+        - web
+      middlewares:
+        - redirect-to-https@file
+        - keycloak-headers@file
+        - public-endpoints@file # Allow all IPs for authentication
+      priority: 600 # Higher priority than the catch-all redirect
+
+    auth-hccc-keycloak-secure-router:
+      rule: "Host(`auth.hccc.edu`, `130.156.44.53`)"
+      service: keycloak-service
+      entryPoints:
+        - websecure
+      tls: {}
+      middlewares:
+        - keycloak-headers@file
+        - public-endpoints@file # Allow all IPs for authentication
+      priority: 600
+
+    # Keep static assets routes for compatibility
+    auth-hccc-static-assets-router:
       rule: "Host(`auth.hccc.edu`, `130.156.44.53`) && PathPrefix(`/static/assets/`)"
       service: api-service
       entryPoints:
@@ -128,39 +152,6 @@ http:
         - public-endpoints@file
         - security-headers@file
       priority: 540
-
-    auth-hccc-access-restricted-page-router: # Serves the actual restricted page
-      rule: "Host(`auth.hccc.edu`, `130.156.44.53`) && Path(`/static/access-restricted.html`)"
-      service: api-service
-      entryPoints:
-        - web
-      middlewares:
-        - redirect-to-https@file
-        - public-endpoints@file
-        - security-headers@file
-      priority: 530
-
-    auth-hccc-access-restricted-page-secure-router:
-      rule: "Host(`auth.hccc.edu`, `130.156.44.53`) && Path(`/static/access-restricted.html`)"
-      service: api-service
-      entryPoints:
-        - websecure
-      tls: {}
-      middlewares:
-        - public-endpoints@file
-        - security-headers@file
-      priority: 530
-
-    auth-hccc-catch-all-redirect-router: # Catches ALL paths on auth.hccc.edu
-      rule: "Host(`auth.hccc.edu`, `130.156.44.53`)"
-      service: api-service # Dummy service
-      entryPoints:
-        - web
-        - websecure # Important
-      tls: {} # For websecure
-      middlewares:
-        - access-restricted-redirect@file
-      priority: 90 # Lowest priority for this host
 
     # --- Admin Endpoints (Internal Only) ---
     admin-api-router:
@@ -355,6 +346,19 @@ http:
         sourceRange:
           - "0.0.0.0/0" # Allow all
 
+    keycloak-headers:
+      headers:
+        customResponseHeaders:
+          X-Content-Type-Options: "nosniff"
+          X-XSS-Protection: "1; mode=block"
+        stsSeconds: 31536000
+        stsIncludeSubdomains: true
+        forceSTSHeader: true
+        # Adjust CSP for Keycloak's needs
+        contentSecurityPolicy: "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; font-src 'self'; frame-ancestors 'self'; object-src 'none';"
+        # Allow Keycloak to be embedded in iframes from the same origin
+        customFrameOptionsValue: "SAMEORIGIN"
+
     security-headers:
       headers:
         customResponseHeaders:
@@ -394,6 +398,12 @@ http:
       loadBalancer:
         servers:
           - url: "http://api:8000" # Points to your FastAPI app container
+        passHostHeader: true
+
+    keycloak-service:
+      loadBalancer:
+        servers:
+          - url: "http://keycloak_service:8080" # Points to the Keycloak container
         passHostHeader: true
 
     prometheus-service:

--- a/keycloak_stack/README.md
+++ b/keycloak_stack/README.md
@@ -1,0 +1,41 @@
+# Keycloak SSO Setup
+
+This directory contains the Docker Compose configuration for setting up Keycloak SSO with a PostgreSQL database.
+
+## Configuration
+
+- **Keycloak Version**: 24.0.1
+- **PostgreSQL Version**: 15
+- **External Access**: https://auth.hccc.edu (configured in the docker-compose file)
+- **Initial Admin Access**: http://localhost:8180 or http://<VM_IP>:8180 (direct port mapping)
+
+## Setup Instructions
+
+1. Make sure to update the `.env` file with secure credentials before starting
+2. Ensure the Docker network `qr_generator_network` exists
+3. Start the Keycloak stack:
+
+```bash
+cd keycloak_stack
+docker-compose -f docker-compose.keycloak.yml up -d
+```
+
+4. Access the Keycloak Admin Console at `http://localhost:8180` or `http://<VM_IP>:8180`
+5. Log in using the admin credentials specified in the `.env` file
+
+## Volumes
+
+- `keycloak_postgres_data`: Persistent storage for the PostgreSQL database
+- `keycloak_data`: Persistent storage for Keycloak data
+
+## Network
+
+The stack connects to the existing `qr_generator_network` to allow communication with the QR Generator application.
+
+## Next Steps
+
+After launching Keycloak, proceed with:
+
+1. Creating the `hccc-apps-realm` in Keycloak Admin Console
+2. Configuring Azure AD as an OIDC Identity Provider
+3. Setting up the OIDC client for `oauth2-proxy` 

--- a/keycloak_stack/docker-compose.keycloak.yml
+++ b/keycloak_stack/docker-compose.keycloak.yml
@@ -1,0 +1,65 @@
+version: '3'
+
+services:
+  # PostgreSQL Database for Keycloak
+  keycloak-db:
+    image: postgres:15
+    container_name: keycloak_postgres
+    environment:
+      - POSTGRES_DB=keycloak
+      - POSTGRES_USER=${KC_DB_USERNAME:-keycloak}
+      - POSTGRES_PASSWORD=${KC_DB_PASSWORD:-keycloak_password}
+      - TZ=America/New_York
+    volumes:
+      - keycloak_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${KC_DB_USERNAME:-keycloak} -d keycloak"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+    networks:
+      - shared-services-network
+
+  # Keycloak Service
+  keycloak:
+    image: quay.io/keycloak/keycloak:24.0.1
+    container_name: keycloak_service
+    command: start-dev
+    environment:
+      - KC_DB=postgres
+      - KC_DB_URL=jdbc:postgresql://keycloak-db:5432/keycloak
+      - KC_DB_USERNAME=${KC_DB_USERNAME:-keycloak}
+      - KC_DB_PASSWORD=${KC_DB_PASSWORD:-keycloak_password}
+      - KEYCLOAK_ADMIN=${KEYCLOAK_ADMIN:-admin}
+      - KEYCLOAK_ADMIN_PASSWORD=${KEYCLOAK_ADMIN_PASSWORD:-admin_password}
+      - KC_PROXY=edge
+      - KC_HTTP_ENABLED=true
+      - KC_HTTP_PORT=8080
+      - TZ=America/New_York
+    ports:
+      - "8180:8080"
+    volumes:
+      - keycloak_data:/opt/keycloak/data
+    depends_on:
+      keycloak-db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health/ready"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - shared-services-network
+
+networks:
+  shared-services-network:
+    name: qr_generator_network
+    external: true
+
+volumes:
+  keycloak_postgres_data:
+    driver: local
+  keycloak_data:
+    driver: local 


### PR DESCRIPTION
## Description
This PR implements the first phases of the OIDC authentication for the QR App, focused on creating a protected `/hello-secure` page as a Minimum Viable Deployment (MVD). It also addresses a critical production issue with QR code directory permissions.

### Key Changes
- Added Keycloak containerized environment for OIDC authentication
- Created a protected `/hello-secure` endpoint to display authenticated user information
- Fixed critical permission error with QR code directory by using a named volume
- Configured Keycloak service in Traefik for proper routing

### Completed Tasks
- ✅ K.1.1: Prepare Docker Environment for Keycloak Stack
- ✅ K.1.2: Set up Keycloak realm with Google as temporary IdP
- ✅ K.1.3: Configure OIDC Client for oauth2-proxy
- ✅ K.2.1: Create Protected `/hello-secure` Page in QR App
- ⬜ K.2.2: Integrate oauth2-proxy into QR App Docker Compose (In Progress)

### Fixed Issues
- Fixed permission denied error on `/app/app/static/assets/images/qr_codes` that was causing application startup failures
- Added proper volume mounting strategy to maintain correct permissions

## Testing Instructions
1. Start the Keycloak stack:
   ```
   cd keycloak_stack
   docker-compose -f docker-compose.keycloak.yml up -d
   ```

2. Verify Keycloak is accessible at http://localhost:8180 with admin credentials

3. Ensure the QR app is running properly with the permission fix:
   ```
   docker-compose up -d
   ```

4. Verify QR code generation works without permission errors

5. The `/hello-secure` endpoint is prepared but won't show authentication information until sub-task K.2.2 is completed

## Notes
- Production error has been fixed in this PR (QR code directory permissions)
- Keycloak is configured with Google as temporary IdP until Azure AD is available
- Still pending: oauth2-proxy integration and Traefik configuration for auth routing

## Screenshots

![image](https://github.com/user-attachments/assets/d253139a-ee0a-44c5-9790-650eee5f47a6)
